### PR TITLE
fix: remove usage of deprecated `url.parse` api

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# @zkochan/npm-package-arg
+# @pnpm/npm-package-arg
 
 Parses package name and specifier passed to commands like `npm install` or
 `npm cache add`, or as found in `package.json` dependency sections.
@@ -7,7 +7,7 @@ Parses package name and specifier passed to commands like `npm install` or
 
 ```javascript
 var assert = require("assert")
-var npa = require("@zkochan/npm-package-arg")
+var npa = require("@pnpm/npm-package-arg")
 
 // Pass in the descriptor, and it'll return an object
 try {
@@ -19,7 +19,7 @@ try {
 
 ## USING
 
-`var npa = require('@zkochan/npm-package-arg')`
+`var npa = require('@pnpm/npm-package-arg')`
 
 ### var result = npa(*arg*[, *where*])
 
@@ -45,7 +45,7 @@ included then the default is `latest`.
 
 ## RESULT OBJECT
 
-The objects that are returned by @zkochan/npm-package-arg contain the following
+The objects that are returned by @pnpm/npm-package-arg contain the following
 keys:
 
 * `type` - One of the following strings:

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Parse the things that can be arguments to `npm install`",
   "main": "npa.js",
   "engines": {
-    "node": ">=14.6"
+    "node": ">=18.12"
   },
   "directories": {
     "test": "test"

--- a/test/basic.js
+++ b/test/basic.js
@@ -2,6 +2,13 @@ var npa = require('../npa.js')
 var path = require('path')
 var os = require('os')
 
+const normalizePath = p => p && p.replace(/^[a-zA-Z]:/, '').replace(/\\/g, '/')
+const normalizePaths = spec => {
+  spec.saveSpec = normalizePath(spec.saveSpec)
+  spec.fetchSpec = normalizePath(spec.fetchSpec)
+  return spec
+}
+
 require('tap').test('basic', function (t) {
   t.setMaxListeners(999)
 
@@ -423,12 +430,14 @@ require('tap').test('basic', function (t) {
   }
 
   Object.keys(tests).forEach(function (arg) {
-    var res = npa(arg, '/test/a/b')
-    t.ok(res instanceof npa.Result, arg + ' is a result')
-    Object.keys(tests[arg]).forEach(function (key) {
-      t.has(res[key], tests[arg][key], arg + ' [' + key + ']')
+    t.test(arg, t => {
+      const res = normalizePaths(npa(arg, '/test/a/b'))
+      t.ok(res instanceof npa.Result, arg + ' is a result')
+      Object.keys(tests[arg]).forEach(function (key) {
+        t.match(res[key], tests[arg][key], arg + ' [' + key + ']')
+      })
+      t.end()
     })
-    //    t.has(res, tests[arg], arg + ' matches expectations')
   })
 
   var objSpec = { name: 'foo', rawSpec: '1.2.3' }


### PR DESCRIPTION
needed to solve pnpm/pnpm#9529

version `2.0.0` of this package should be created and released after this gets merged